### PR TITLE
Changed the Documentation nav link's url path

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -29,7 +29,7 @@
 				<img id="logo" src="/images/logo.png" alt="Crafty - JavaScript HTML5 Game Engine" /></a>
 			<ul>
 				<li><a href="/tutorial/">Getting Started</a></li>
-				<li><a href="/api/">Documentation</a></li>
+				<li><a href="../api/">Documentation</a></li>
 				<li><a href="https://groups.google.com/forum/#!forum/craftyjs">Forum</a></li>
 				<li><a href="http://craftycomponents.com/">Modules</a></li>
 				<li class="emph"><a href="/release/0.5.3/crafty.js">Download</a></li>


### PR DESCRIPTION
Old URL path would direct to craftyjs.com/api/api/ if clicked while on the Documentation page already, which was resulting in a 404.

New path properly goes to the Documentation page if already on it, as well as the other pages. 

Please see the url in the status bar of the attached image for clarification.
![Screen Shot 2013-02-04 at 4 17 30 AM](https://f.cloud.github.com/assets/92724/123480/f62d3328-6ec4-11e2-8775-347860149614.png)
![Screen Shot 2013-02-04 at 4 19 00 AM](https://f.cloud.github.com/assets/92724/123482/18ac8606-6ec5-11e2-9268-721b2e323c0c.png)
