### PR TITLE
download links to actual js not GH page source

### DIFF
--- a/download/index.md
+++ b/download/index.md
@@ -9,8 +9,8 @@ The script can be downloaded in normal and minified versions.
 
 Normal:
 
-<div><a href="https://github.com/craftyjs/Crafty/blob/release/dist/crafty.js" download="crafty.js">crafty.js</a></div>
+<div><a href="https://raw.github.com/craftyjs/Crafty/release/dist/crafty.js" download="crafty.js">crafty.js</a></div>
 
 Minified:
 
-<div><a href="https://github.com/craftyjs/Crafty/blob/release/dist/crafty-min.js" download="crafty-min.js">crafty-min.js</a></div>
+<div><a href="https://raw.github.com/craftyjs/Crafty/release/dist/crafty-min.js" download="crafty-min.js">crafty-min.js</a></div>


### PR DESCRIPTION
Issue: Download links under http://craftyjs.com/download/ download the html for the JS
Fix: Download links correspond to actual JS
Comments:
I'm not sure what's the intended behavior for the website. I noticed download on the main page sends the user to the github page. Should these download links link to the github pages respectively but not download?
