### PR TITLE
Incorrect link

### DIFF
--- a/release/0.5.4/api/Crafty-HashMap.html
+++ b/release/0.5.4/api/Crafty-HashMap.html
@@ -41,6 +41,6 @@ The <code>cellsize</code> is 64 by default.</p>
 <h3>See Also</h3>
 
 <ul>
-<li><a href="Crafty-HashMap-constructor.html">Crafty.HashMap.constructor</a></li>
+<li><a href="#Crafty-HashMap-constructor">Crafty.HashMap.constructor</a></li>
 </ul>
 </div></div>


### PR DESCRIPTION
Internal link, not external resource.
