### PR TITLE
Add more documentation for entities, components, and events

### DIFF
--- a/documentation/2d.html
+++ b/documentation/2d.html
@@ -64,6 +64,21 @@
 						</a>
 					</li>
 					<li>
+						<a href='/documentation/entities.html'>
+							Entities
+						</a>
+					</li>
+					<li>
+						<a href='/documentation/events.html'>
+							Events
+						</a>
+					</li>
+					<li>
+						<a href='/documentation/components.html'>
+							Components
+						</a>
+					</li>
+					<li>
 						<a href='/documentation/2d.html'>
 							2D Graphics
 						</a>

--- a/documentation/components.html
+++ b/documentation/components.html
@@ -1,0 +1,233 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+	<title>Crafty - Custom Components</title>
+	<link type="text/css" rel="stylesheet" href="/craftyjs-site.css" />
+
+	<link href='http://fonts.googleapis.com/css?family=Arvo:regular,bold' rel='stylesheet' 	type='text/css'>
+	<link href='http://fonts.googleapis.com/css?family=Open+Sans:400,300,600' rel='stylesheet' type='text/css'>
+	<link rel="shortcut icon" href="/favicon.ico">
+	<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.5.2/jquery.min.js" type="text/javascript"></script>
+	<link rel="stylesheet" href="/github.css"/>
+	<script type="text/javascript">
+
+		var _gaq = _gaq || [];
+		_gaq.push(['_setAccount', 'UA-23935213-2']);
+		_gaq.push(['_trackPageview']);
+
+		(function () {
+			var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
+			ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+			var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
+		})();
+
+	</script>
+</head>
+<body>
+	<div id = "header-background"> </div>
+	<div id = "page-frame">
+	<div id="header">
+		<nav class="navbar">
+  			<div class="container-fluid">
+  				<div class="navbar-header">
+  					<a class="navbar-brand" href="/"> <img class="logo" src="/images/text-logo.png" /> </a>
+  					
+				</div>
+				<div class="collapse navbar-collapse navbar-right" id="bs-example-navbar-collapse-1">
+					<ul class="nav navbar-nav">
+						<li><a href="/">Home</a></li>
+						<li><a href="/getting-started/">Getting started</a></li>
+						<li><a href="/documentation/">Documentation</a></li>
+						<li><a href="/api/">API</a></li>
+						<li><a href="https://groups.google.com/forum/#!forum/craftyjs">Forum</a></li>
+						<li><a href="/components/">Components</a></li>
+						<li class="emph"><a href="/#install">Download</a></li>
+					</ul>
+				</div>
+			</div>
+		</nav>
+	</div>
+
+
+	<div id="main">
+		<div id="content" class="container">
+			
+<div id="docs">
+	<div id='doc-nav'>
+		<ul id='doc-level-one'>
+			<li>
+				Topics
+				<ul>
+					<li>
+						<a href='/documentation/'>
+							Documentation
+						</a>
+					</li>
+					<li>
+						<a href='/documentation/entities.html'>
+							Entities
+						</a>
+					</li>
+					<li>
+						<a href='/documentation/events.html'>
+							Events
+						</a>
+					</li>
+					<li>
+						<a href='/documentation/components.html'>
+							Components
+						</a>
+					</li>
+					<li>
+						<a href='/documentation/2d.html'>
+							2D Graphics
+						</a>
+					</li>
+					<li>
+						<a href='/documentation/text.html'>
+							Text
+						</a>
+					</li>
+					<li>
+						<a href='/documentation/keyboard.html'>
+							Keyboard
+						</a>
+					</li>
+					<li>
+						<a href='/documentation/mouse.html'>
+							Mouse
+						</a>
+					</li>
+					<li>
+						<a href='/documentation/sound.html'>
+							Sound
+						</a>
+					</li>
+					<li>
+						<a href='/documentation/sprites.html'>
+							Sprites
+						</a>
+					</li>
+					<li>
+						<a href='/documentation/scenes.html'>
+							Scenes
+						</a>
+					</li>
+					<li>
+						<a href='/documentation/gameloop.html'>
+							Game Loop
+						</a>
+					</li>
+				</ul>
+			</li>
+		</ul>
+	</div>
+	<div id='doc-content' class="markdown">
+		<span class="edit-on-github">
+		  <a href="https://github.com/craftyjs/craftyjs.github.com/edit/master/source/documentation/components.md">Edit on Github</a>
+		</span>
+
+		<h2> Custom Components </h2>
+		<p>Crafty has a lot of built-in components, but creating your own is a good way to organize your game.</p>
+<p>In several examples we&#39;ve created colored squares, and we&#39;ve repeated that code a <em>lot</em>.  For instance, the code below creates two squares:</p>
+<pre><code><span class="hljs-keyword">var</span> sq1 = Crafty.e(<span class="hljs-string">"2D, Canvas, Color"</span>)
+    .attr({x:<span class="hljs-number">10</span>, y:<span class="hljs-number">10</span>, w:<span class="hljs-number">30</span>, h:<span class="hljs-number">30</span>})
+    .color(<span class="hljs-string">"red"</span>);
+<span class="hljs-keyword">var</span> sq1 = Crafty.e(<span class="hljs-string">"2D, Canvas, Color"</span>)
+    .attr({x:<span class="hljs-number">150</span>, y:<span class="hljs-number">100</span>, w:<span class="hljs-number">30</span>, h:<span class="hljs-number">30</span>})
+    .color(<span class="hljs-string">"green"</span>);</code></pre>
+<p>Now, you could create a function that simply generates such a square, but the Crafty way is to use components.  Define a component by using <a href="/api/Crafty-c.html"><code>Crafty.c</code></a>.</p>
+<pre><code>Crafty.c(<span class="hljs-string">"Square"</span>, {
+    <span class="hljs-comment">// This function will be called when the component is added to an entity</span>
+    <span class="hljs-comment">// So it sets up the things that both our entities had in common</span>
+    init: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">()</span> </span>{
+        <span class="hljs-keyword">this</span>.addComponent(<span class="hljs-string">"2D, Canvas, Color"</span>);
+        <span class="hljs-keyword">this</span>.w = <span class="hljs-number">30</span>;
+        <span class="hljs-keyword">this</span>.h = <span class="hljs-number">30</span>;
+    },
+
+    <span class="hljs-comment">// Our two entities had different positions, </span>
+    <span class="hljs-comment">// so we define a method for setting the position</span>
+    place: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(x, y)</span> </span>{
+        <span class="hljs-keyword">this</span>.x = x;
+        <span class="hljs-keyword">this</span>.y = y;
+
+        <span class="hljs-comment">// There's no magic to method chaining.</span>
+        <span class="hljs-comment">// To allow it, we have to return the entity!</span>
+        <span class="hljs-keyword">return</span> <span class="hljs-keyword">this</span>;
+    }
+})</code></pre>
+<p><code>Crafty.c</code> takes two arguments: the first is the name of the component, the second is an object which defines its methods and properties.  When the component is added to an entity, all the methods and properties are copied to the entity in question.  The <code>init</code> field is treated specially, and is called when the component is added to an entity.  (You can also define a <code>remove</code> function that will be run when the component is removed, or right before the entity is destroyed.)</p>
+<p>With the above definition, our original code could be rewritten as</p>
+<pre><code><span class="hljs-keyword">var</span> sq1 = Crafty.e(<span class="hljs-string">"Square"</span>)
+    .place(<span class="hljs-number">10</span>, <span class="hljs-number">10</span>)
+    .color(<span class="hljs-string">"red"</span>);
+
+<span class="hljs-keyword">var</span> sq2 = Crafty.e(<span class="hljs-string">"Square"</span>)
+    .place(<span class="hljs-number">150</span>, <span class="hljs-number">100</span>)
+    .color(<span class="hljs-string">"green"</span>);</code></pre>
+<p>We&#39;ve taken everything that the two entities had in common, and put it in the <code>init</code> function of our component.  This is a very common way to reuse code between entities.  In some ways it&#39;s a bit like &quot;Square&quot; inherits the methods of the other components; by adding &quot;Square&quot; to an entity, we automatically get all the methods of &quot;Color&quot;.</p>
+<p>Keep in mind that the method chaining technique (calling <code>e.place().color()</code>) is only possible because we explicitly return <code>this</code> from our custom method.  Forgetting to do so can be a common source of errors, so keep that in mind if you get a hard-to-pin-down &quot;method undefined&quot; message.</p>
+<h2 id="the-nitty-gritty">The nitty gritty</h2>
+<p>Sometimes you might need to know exactly how components are added to an entity.  (If the component has previously been added to an entity, it won&#39;t be further modified.)</p>
+<ul>
+<li>First a flag indicating the existence of the component is set</li>
+<li>Then all properties are copied over from the component&#39;s object.  If any already exist, they will be overwritten.</li>
+<li>If a property is an object or array, it is copied by reference.</li>
+<li>Finally, the init function of the component object is called.</li>
+</ul>
+<h3 id="the-shared-object-trap">The shared object trap</h3>
+<p>As mentioned above, objects and arrays are copied by reference.  This can cause unexpected behavior if you&#39;re not careful:</p>
+<pre><code>Crafty.c(<span class="hljs-string">"MyComponent"</span>, {
+    sharedObject: {a:<span class="hljs-number">1</span>, b:<span class="hljs-number">2</span>}
+});
+<span class="hljs-keyword">var</span> e1 = Crafty.e(<span class="hljs-string">"MyComponent"</span>);
+<span class="hljs-keyword">var</span> e2 = Crafty.e(<span class="hljs-string">"MyComponent"</span>);
+e1.sharedObject.a = <span class="hljs-number">5</span>;
+<span class="hljs-built_in">console</span>.log(e2.sharedObject.a); <span class="hljs-comment">// Logs 5!</span></code></pre>
+<p>If you want a property to be an object, but <em>don&#39;t</em> want it shared between entities, the solution is to create a new object inside the init method:</p>
+<pre><code>Crafty.c(<span class="hljs-string">"MyComponent"</span>, {
+    init: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">()</span> </span>{
+        <span class="hljs-keyword">this</span>.myObject = {a:<span class="hljs-number">1</span>, b:<span class="hljs-number">2</span>};
+    }
+});
+<span class="hljs-keyword">var</span> e1 = Crafty.e(<span class="hljs-string">"MyComponent"</span>);
+<span class="hljs-keyword">var</span> e2 = Crafty.e(<span class="hljs-string">"MyComponent"</span>);
+e1.myObject.a = <span class="hljs-number">5</span>;
+<span class="hljs-built_in">console</span>.log(e2.myObject.a); <span class="hljs-comment">// Logs the original value of 1</span></code></pre>
+
+	</div>
+</div>
+			
+		</div>
+	</div>
+	<div class="clearer"></div>
+	<div id="footer">
+		<div id="contact">
+			<a href="https://groups.google.com/forum/#!forum/craftyjs">
+				<img src="/images/google.png" />
+				google groups</a>
+			<a href="mailto:starwed@gmail.com">
+				<img src="/images/email.png" />
+				starwed@gmail.com</a>
+			<a href="https://github.com/craftyjs/Crafty">
+				<img src="/images/github.png" />
+				github</a>
+		</div>
+		<ul>
+			<li><a href="/">Home</a></li>
+				<li><a href="/getting-started/">Getting started</a></li>
+				<li><a href="/documentation/">Documentation</a></li>
+				<li><a href="/api/">API</a></li>
+				<li><a href="https://groups.google.com/forum/#!forum/craftyjs">Forum</a></li>
+				<li><a href="/components/">Modules</a></li>
+				<li class="emph"><a href="/#install">Download</a></li>
+		</ul>
+		<p>
+			&copy; Crafty 2010-2015. Crafty is distributed under the <a href="http://en.wikipedia.org/wiki/MIT_License">MIT</a> or <a href="http://en.wikipedia.org/wiki/GNU_General_Public_License">GPL</a>
+			license.
+		</p>
+	</div>
+</div>
+</body>
+</html>

--- a/documentation/entities.html
+++ b/documentation/entities.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-	<title>Crafty - </title>
+	<title>Crafty - Working with entities</title>
 	<link type="text/css" rel="stylesheet" href="/craftyjs-site.css" />
 
 	<link href='http://fonts.googleapis.com/css?family=Arvo:regular,bold' rel='stylesheet' 	type='text/css'>
@@ -52,6 +52,157 @@
 	<div id="main">
 		<div id="content" class="container">
 			
+<div id="docs">
+	<div id='doc-nav'>
+		<ul id='doc-level-one'>
+			<li>
+				Topics
+				<ul>
+					<li>
+						<a href='/documentation/'>
+							Documentation
+						</a>
+					</li>
+					<li>
+						<a href='/documentation/entities.html'>
+							Entities
+						</a>
+					</li>
+					<li>
+						<a href='/documentation/events.html'>
+							Events
+						</a>
+					</li>
+					<li>
+						<a href='/documentation/components.html'>
+							Components
+						</a>
+					</li>
+					<li>
+						<a href='/documentation/2d.html'>
+							2D Graphics
+						</a>
+					</li>
+					<li>
+						<a href='/documentation/text.html'>
+							Text
+						</a>
+					</li>
+					<li>
+						<a href='/documentation/keyboard.html'>
+							Keyboard
+						</a>
+					</li>
+					<li>
+						<a href='/documentation/mouse.html'>
+							Mouse
+						</a>
+					</li>
+					<li>
+						<a href='/documentation/sound.html'>
+							Sound
+						</a>
+					</li>
+					<li>
+						<a href='/documentation/sprites.html'>
+							Sprites
+						</a>
+					</li>
+					<li>
+						<a href='/documentation/scenes.html'>
+							Scenes
+						</a>
+					</li>
+					<li>
+						<a href='/documentation/gameloop.html'>
+							Game Loop
+						</a>
+					</li>
+				</ul>
+			</li>
+		</ul>
+	</div>
+	<div id='doc-content' class="markdown">
+		<span class="edit-on-github">
+		  <a href="https://github.com/craftyjs/craftyjs.github.com/edit/master/source/documentation/entities.md">Edit on Github</a>
+		</span>
+
+		<h2> Working with entities </h2>
+		<p>An entity is some <em>thing</em> in your game.  If that sounds vague, it&#39;s because practically anything can be an entity -- the player, the enemies, a projectile, a high score counter, or a menu item.</p>
+<p>Entities are made up of components, which you can think of as bundles of functionality.  Crafty provides several built-in components, and you can also define your own with <a href="/api/Crafty-c.html"><code>Crafty.c()</code></a>.</p>
+<h2 id="creating-entities">Creating entities</h2>
+<p>You create an entity with <a href="/api/Craft-e.html"><code>Crafty.e()</code></a>.  In most cases you&#39;ll pass in a list of the components you want to start with:</p>
+<pre><code><span class="hljs-keyword">var</span> square = Crafty.e(<span class="hljs-string">"2D, Canvas, Color"</span>);</code></pre>
+<p>Typically you&#39;ll need to write some more code to actually <em>do</em> something with the entity, but the above is all you need to create it.  In fact, you don&#39;t even need to assign the entity to a variable -- just calling <code>Crafty.e</code> is enough, and we&#39;ll learn later how to manipulate entities without a direct reference.</p>
+<h2 id="core-properties-and-methods">Core properties and methods</h2>
+<p>There are certain properties and methods that every entity shares, even if no components have been added.  You&#39;ll find these documented under <a href="/api/Crafty Core.html">Crafty Core</a>.</p>
+<h3 id="component-methods">Component methods</h3>
+<p>You can <a href="api/Crafty Core.html#-addComponent">add</a> and <a href="http://craftyjs.com/api/Crafty%20Core.html#-removeComponent">remove</a> components to an entity after it has been created.  So instead of our previous code, we could have written:</p>
+<pre><code><span class="hljs-keyword">var</span> square = Crafty.e(<span class="hljs-string">"2D, Canvas"</span>);
+square.addComponent(<span class="hljs-string">"Color"</span>);</code></pre>
+<p>If we no longer wanted our component to appear as a colored square, we could remove that component later:</p>
+<pre><code>square.removeComponent(<span class="hljs-string">"Color"</span>, <span class="hljs-literal">false</span>)</code></pre>
+<p>We pass in <code>false</code> to <code>removeComponent()</code> because we want to actually remove all properties and methods associated with the component.</p>
+<p>To learn whether an entity has a particular component, you can use the <code>has()</code> method.  For instance, perhaps we want to check if an entity might explode:</p>
+<pre><code><span class="hljs-keyword">if</span> (e.has(<span class="hljs-string">"Explode"</span>))
+    e.explode();</code></pre>
+<h3 id="setting-properties">Setting properties</h3>
+<p>A component such as <a href="/api/api.html">2D</a> might interact with certain properties of an entity.  You can set them directly, or use <code>attr</code> as a shorthand for setting several at once.  So this:</p>
+<pre><code>square.x = 5;
+square.y = 10;</code></pre>
+<p>is equivalent to</p>
+<pre><code>square.attr({x:5, y:10})</code></pre>
+<h3 id="events">Events</h3>
+<p>Crafty uses both global and local events for communication amongst entities and components.  To create an event listener, you can use the <code>.bind()</code> method.  Let&#39;s make our previous square switch colors in response to an event.</p>
+<pre><code><span class="hljs-comment">// Bind a function to the event</span>
+square.bind(<span class="hljs-string">"ChangeColor"</span>, <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(eventData)</span></span>{
+        <span class="hljs-comment">// `this` refers to the entity</span>
+        <span class="hljs-keyword">this</span>.color(eventData.color);
+    })
+<span class="hljs-comment">// Trigger that event directly on the entity</span>
+square.trigger(<span class="hljs-string">"ChangeColor"</span>, {color:<span class="hljs-string">"blue"</span>});</code></pre>
+<p>In the above code, we directly trigger the effect on the entity.  You can also trigger an effect globally, which means <em>all</em> entities will receive it.  Events are often used for communication between components -- you can find information about such events in the component&#39;s documentation.</p>
+<p>If a function should only be triggered once, you can bind with the <code>one()</code> method instead of <code>bind()</code>.  To remove a bound event, use <code>unbind()</code>.</p>
+<p>See the section on <a href="/documentation/events.html">events</a> for more discussion of the event system.</p>
+<h3 id="destruction">Destruction</h3>
+<p>Calling the <code>destroy()</code> method of an entity will destroy it.</p>
+<h2 id="selecting-entities">Selecting entities</h2>
+<p>When an entity is created, it&#39;s given a unique ID.  To find this id, you can call the <code>getId()</code> method.</p>
+<p>If you know the id of an entity, you can get a reference to it like this:</p>
+<pre><code><span class="hljs-keyword">var</span> secondEntity = Crafty(<span class="hljs-number">2</span>);</code></pre>
+<p><a href="/api/Crafty.html"><code>Crafty</code></a> is both an object and a function.  This might be familiar to you from working with jQuery.  And as in jQuery, you can select multiple entities at once, typically based on what components they have:</p>
+<pre><code><span class="hljs-comment">// Select all entities with the 2D components</span>
+Crafty(<span class="hljs-string">"2D"</span>);
+<span class="hljs-comment">// select all entities with both 2D and DOM</span>
+Crafty(<span class="hljs-string">"2D DOM"</span>);
+<span class="hljs-comment">// select entities with either DOM or Canvas</span>
+Crafty(<span class="hljs-string">"DOM, Canvas"</span>);
+<span class="hljs-comment">// Select all entities</span>
+Crafty(<span class="hljs-string">"*"</span>);</code></pre>
+<p>Once you have a selection, you can call event-related methods directly:</p>
+<pre><code><span class="hljs-comment">// Bind a function to *every* entity with the Keyboard component</span>
+Crafty(<span class="hljs-string">"Keyboard"</span>).bind(<span class="hljs-string">"KeyDown"</span>, <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">()</span></span>{
+    <span class="hljs-comment">// Do something on keydown</span>
+});
+
+<span class="hljs-comment">// Explode all the things!</span>
+Crafty(<span class="hljs-string">"*"</span>).trigger(<span class="hljs-string">"Explode"</span>);</code></pre>
+<p>You can run a function in the context of every entity:</p>
+<pre><code><span class="hljs-comment">// Move every 2D entity 5 pixels to the right</span>
+Crafty(<span class="hljs-string">"2D"</span>).each(<span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">()</span> </span>{
+    <span class="hljs-keyword">this</span>.x += <span class="hljs-number">5</span>;
+});</code></pre>
+<p>If you need to know how many entities are in the selection, you can check the <code>length</code> property.</p>
+<p>You can use <code>get()</code> to either obtain an array containing every entity in the selection, or the entity at a particular index:</p>
+<pre><code><span class="hljs-comment">// Get the first Canvas entity</span>
+<span class="hljs-keyword">var</span> first_entity = Crafty(<span class="hljs-string">"Canvas"</span>).get(<span class="hljs-number">0</span>);
+<span class="hljs-comment">// Get an array of all 2D entities</span>
+<span class="hljs-keyword">var</span> array_of_entities = Crafty(<span class="hljs-string">"2D"</span>).get();
+<span class="hljs-comment">// Convert to an array of ids, rather than entities</span>
+<span class="hljs-keyword">var</span> array_of_ids = Crafty(<span class="hljs-string">"2D"</span>).toArray();</code></pre>
+
+	</div>
+</div>
 			
 		</div>
 	</div>
@@ -74,8 +225,8 @@
 				<li><a href="/documentation/">Documentation</a></li>
 				<li><a href="/api/">API</a></li>
 				<li><a href="https://groups.google.com/forum/#!forum/craftyjs">Forum</a></li>
-				<li><a href="/modules/">Modules</a></li>
-				<li class="emph"><a href="/download/">Download</a></li>
+				<li><a href="/components/">Modules</a></li>
+				<li class="emph"><a href="/#install">Download</a></li>
 		</ul>
 		<p>
 			&copy; Crafty 2010-2015. Crafty is distributed under the <a href="http://en.wikipedia.org/wiki/MIT_License">MIT</a> or <a href="http://en.wikipedia.org/wiki/GNU_General_Public_License">GPL</a>

--- a/documentation/events.html
+++ b/documentation/events.html
@@ -1,0 +1,252 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+	<title>Crafty - The Event System</title>
+	<link type="text/css" rel="stylesheet" href="/craftyjs-site.css" />
+
+	<link href='http://fonts.googleapis.com/css?family=Arvo:regular,bold' rel='stylesheet' 	type='text/css'>
+	<link href='http://fonts.googleapis.com/css?family=Open+Sans:400,300,600' rel='stylesheet' type='text/css'>
+	<link rel="shortcut icon" href="/favicon.ico">
+	<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.5.2/jquery.min.js" type="text/javascript"></script>
+	<link rel="stylesheet" href="/github.css"/>
+	<script type="text/javascript">
+
+		var _gaq = _gaq || [];
+		_gaq.push(['_setAccount', 'UA-23935213-2']);
+		_gaq.push(['_trackPageview']);
+
+		(function () {
+			var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
+			ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+			var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
+		})();
+
+	</script>
+</head>
+<body>
+	<div id = "header-background"> </div>
+	<div id = "page-frame">
+	<div id="header">
+		<nav class="navbar">
+  			<div class="container-fluid">
+  				<div class="navbar-header">
+  					<a class="navbar-brand" href="/"> <img class="logo" src="/images/text-logo.png" /> </a>
+  					
+				</div>
+				<div class="collapse navbar-collapse navbar-right" id="bs-example-navbar-collapse-1">
+					<ul class="nav navbar-nav">
+						<li><a href="/">Home</a></li>
+						<li><a href="/getting-started/">Getting started</a></li>
+						<li><a href="/documentation/">Documentation</a></li>
+						<li><a href="/api/">API</a></li>
+						<li><a href="https://groups.google.com/forum/#!forum/craftyjs">Forum</a></li>
+						<li><a href="/components/">Components</a></li>
+						<li class="emph"><a href="/#install">Download</a></li>
+					</ul>
+				</div>
+			</div>
+		</nav>
+	</div>
+
+
+	<div id="main">
+		<div id="content" class="container">
+			
+<div id="docs">
+	<div id='doc-nav'>
+		<ul id='doc-level-one'>
+			<li>
+				Topics
+				<ul>
+					<li>
+						<a href='/documentation/'>
+							Documentation
+						</a>
+					</li>
+					<li>
+						<a href='/documentation/entities.html'>
+							Entities
+						</a>
+					</li>
+					<li>
+						<a href='/documentation/events.html'>
+							Events
+						</a>
+					</li>
+					<li>
+						<a href='/documentation/components.html'>
+							Components
+						</a>
+					</li>
+					<li>
+						<a href='/documentation/2d.html'>
+							2D Graphics
+						</a>
+					</li>
+					<li>
+						<a href='/documentation/text.html'>
+							Text
+						</a>
+					</li>
+					<li>
+						<a href='/documentation/keyboard.html'>
+							Keyboard
+						</a>
+					</li>
+					<li>
+						<a href='/documentation/mouse.html'>
+							Mouse
+						</a>
+					</li>
+					<li>
+						<a href='/documentation/sound.html'>
+							Sound
+						</a>
+					</li>
+					<li>
+						<a href='/documentation/sprites.html'>
+							Sprites
+						</a>
+					</li>
+					<li>
+						<a href='/documentation/scenes.html'>
+							Scenes
+						</a>
+					</li>
+					<li>
+						<a href='/documentation/gameloop.html'>
+							Game Loop
+						</a>
+					</li>
+				</ul>
+			</li>
+		</ul>
+	</div>
+	<div id='doc-content' class="markdown">
+		<span class="edit-on-github">
+		  <a href="https://github.com/craftyjs/craftyjs.github.com/edit/master/source/documentation/events.md">Edit on Github</a>
+		</span>
+
+		<h2> The Event System </h2>
+		<p>Crafty uses events for communication.</p>
+<p>The basic idea is to bind functions to named events.  When that event is triggered, the function will then be called directly.  Here&#39;s a very simple example:</p>
+<pre><code><span class="hljs-comment">// Create a red square</span>
+<span class="hljs-keyword">var</span> square = Crafty.e(<span class="hljs-string">"2D, Canvas, Color"</span>)
+        .attr({x:<span class="hljs-number">10</span>,y:<span class="hljs-number">10</span>, w:<span class="hljs-number">30</span>, h:<span class="hljs-number">30</span>})
+        .color(<span class="hljs-string">"blue"</span>);
+
+<span class="hljs-comment">// When a "Blush" event is triggered, turn pink</span>
+square.bind(<span class="hljs-string">"Blush"</span>, <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">()</span> </span>{
+    <span class="hljs-comment">// the function will be called in the context of the entity</span>
+    <span class="hljs-keyword">this</span>.color(<span class="hljs-string">"pink"</span>)
+});
+
+<span class="hljs-comment">// Trigger the event, causing the square to turn pink</span>
+square.trigger(<span class="hljs-string">"Blush"</span>);</code></pre>
+<p>Above, we bind to an event on an entity and then immediately trigger it.  More typically, the event would be triggered elsewhere in the game logic.  You can bind multiple functions to the same event, but you generally shouldn&#39;t rely on them executing in a particular order.</p>
+<p>Every entity automatically gets several methods which relate to events; these are documented under <a href="/api/Crafty Core.html">Crafty Core</a>.  We&#39;ll explore aspects of this in more detail below.    </p>
+<h2 id="passing-data">Passing data</h2>
+<p>Many events pass data to the bound function.  Let&#39;s make the above code a bit more generic by defining a &quot;ChangeColor&quot; event:</p>
+<pre><code>square.bind(<span class="hljs-string">"ChangeColor"</span>, <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(color)</span> </span>{
+    <span class="hljs-keyword">this</span>.color(color);
+});
+
+square.trigger(<span class="hljs-string">"ChangeColor"</span>, <span class="hljs-string">"pink"</span>); <span class="hljs-comment">// Turn pink</span></code></pre>
+<p>When you trigger the event, a single paramter can be passed as the second argument.  This isn&#39;t too limiting, because you can always pass an object -- for instance, if we wanted <code>&quot;ChangeColor&quot;</code> to use rgb values instead of a single name:</p>
+<pre><code><span class="hljs-comment">// Assume that color is an object</span>
+square.bind(<span class="hljs-string">"ChangeColor"</span>, <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(color)</span> </span>{
+    <span class="hljs-keyword">this</span>.color(color.r, color,g, color.b);
+})
+
+<span class="hljs-comment">// Specify the RGB values corresponding to pink</span>
+square.trigger(<span class="hljs-string">"ChangeColor"</span>, {r:<span class="hljs-number">255</span>, g:<span class="hljs-number">192</span>, b:<span class="hljs-number">203</span>});</code></pre>
+<h2 id="unbinding-events">Unbinding events</h2>
+<p>To unbind an event, you need a reference to the bound function, so you typically can&#39;t use an anonymous one.  Modifying our initial example:</p>
+<pre><code><span class="hljs-keyword">var</span> turnPink = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">()</span> </span>{ 
+    <span class="hljs-keyword">this</span>.color(<span class="hljs-string">"pink"</span>);
+}
+
+<span class="hljs-comment">// Bind the function to an event</span>
+square.bind(<span class="hljs-string">"Blush"</span>, turnPink);
+
+<span class="hljs-comment">// Immediately unbind it!</span>
+square.unbind(<span class="hljs-string">"Blush"</span>, turnPink);</code></pre>
+<p>Very commonly, you might want a function to only be triggered once.  In that case, you can bind it with <code>.one()</code> instead of <code>.bind()</code>:</p>
+<pre><code><span class="hljs-comment">// Use the .one() method instead of .bind()</span>
+square.one(<span class="hljs-string">"JumpRight"</span>, <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">()</span> </span>{
+    <span class="hljs-comment">// Move 10 px to the right</span>
+    <span class="hljs-keyword">this</span>.x += <span class="hljs-number">100</span>;
+});
+
+<span class="hljs-comment">// If we trigger the event twice, the bound function will be called only the first time</span>
+square.trigger(<span class="hljs-string">"JumpRight"</span>);
+square.trigger(<span class="hljs-string">"JumpRight"</span>);</code></pre>
+<h2 id="working-with-built-in-events">Working with built-in events</h2>
+<p>Many of Crafty&#39;s built-in components will trigger events, and the more useful ones will be documented in the API reference.  For instance, the <a href="/api/2D.html"><code>2D</code> component</a> tells us that it will trigger a &quot;Move&quot; event any time the object&#39;s position changes, and that the event will pass along an object containing the entity&#39;s old position.</p>
+<pre><code><span class="hljs-comment">// Bind a function to the "Move" event</span>
+<span class="hljs-comment">// It will log the initial and new x position anytime the entity moves</span>
+square.bind(<span class="hljs-string">"Move"</span>, <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(oldPosition)</span> </span>{
+    <span class="hljs-built_in">console</span>.log(oldPosition._x, <span class="hljs-keyword">this</span>.x);
+});
+
+square.x = <span class="hljs-number">100</span>; <span class="hljs-comment">// Will print "10, 100"</span></code></pre>
+<p>As you explore Crafty&#39;s <a href="/api/">API</a>, you&#39;ll see such built-in events highlighted in green.</p>
+<h2 id="global-events">Global events</h2>
+<p>All the events we&#39;ve discussed so far have been local to one specific entity.  But events can be triggered globally as well -- they will then trigger on <em>every</em> entity.</p>
+<pre><code><span class="hljs-comment">// Define two entities at x=5 and x=10</span>
+<span class="hljs-keyword">var</span> varrick = Crafty.e(<span class="hljs-string">"2D"</span>).attr({x:<span class="hljs-number">5</span>});
+<span class="hljs-keyword">var</span> xhuli = Crafty.e(<span class="hljs-string">"2D"</span>).attr({x:<span class="hljs-number">10</span>});
+
+<span class="hljs-comment">// Bind to an event called "Thing"</span>
+varrick.bind(<span class="hljs-string">"Thing"</span>, <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">()</span> </span>{ <span class="hljs-keyword">this</span>.x += <span class="hljs-number">20</span>; });
+xhuli.bind(<span class="hljs-string">"Thing"</span>, <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">()</span> </span>{ <span class="hljs-keyword">this</span>.x += <span class="hljs-number">10</span>; });
+
+<span class="hljs-comment">// Do the thing!</span>
+<span class="hljs-comment">// varrick and xhuli will *both* move to the right</span>
+Crafty.trigger(<span class="hljs-string">"Thing"</span>);
+
+<span class="hljs-comment">// You can still trigger the same events directly on an entity</span>
+xhuli.trigger(<span class="hljs-string">"Thing"</span>);</code></pre>
+<p>You can also bind to events directly on the Crafty object:</p>
+<pre><code>Crafty.bind(<span class="hljs-string">"Thing"</span>, <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">()</span> </span>{
+    <span class="hljs-built_in">console</span>.log(<span class="hljs-string">"Crafty does the thing."</span>)
+});</code></pre>
+<p>In such a globally bound function, the context will be the global Crafty object (<code>this === Crafty</code>).</p>
+<p><code>Crafty.unbind()</code> and <code>Crafty.one()</code> also exist, and act exactly as you&#39;d expect!</p>
+<p>One particularly important built-in global event is &quot;EnterFrame&quot;.  You can read more about it in the section on Crafty&#39;s <a href="/documentation/gameloop.html">game loop</a></p>
+
+	</div>
+</div>
+			
+		</div>
+	</div>
+	<div class="clearer"></div>
+	<div id="footer">
+		<div id="contact">
+			<a href="https://groups.google.com/forum/#!forum/craftyjs">
+				<img src="/images/google.png" />
+				google groups</a>
+			<a href="mailto:starwed@gmail.com">
+				<img src="/images/email.png" />
+				starwed@gmail.com</a>
+			<a href="https://github.com/craftyjs/Crafty">
+				<img src="/images/github.png" />
+				github</a>
+		</div>
+		<ul>
+			<li><a href="/">Home</a></li>
+				<li><a href="/getting-started/">Getting started</a></li>
+				<li><a href="/documentation/">Documentation</a></li>
+				<li><a href="/api/">API</a></li>
+				<li><a href="https://groups.google.com/forum/#!forum/craftyjs">Forum</a></li>
+				<li><a href="/components/">Modules</a></li>
+				<li class="emph"><a href="/#install">Download</a></li>
+		</ul>
+		<p>
+			&copy; Crafty 2010-2015. Crafty is distributed under the <a href="http://en.wikipedia.org/wiki/MIT_License">MIT</a> or <a href="http://en.wikipedia.org/wiki/GNU_General_Public_License">GPL</a>
+			license.
+		</p>
+	</div>
+</div>
+</body>
+</html>

--- a/documentation/gameloop.html
+++ b/documentation/gameloop.html
@@ -64,6 +64,21 @@
 						</a>
 					</li>
 					<li>
+						<a href='/documentation/entities.html'>
+							Entities
+						</a>
+					</li>
+					<li>
+						<a href='/documentation/events.html'>
+							Events
+						</a>
+					</li>
+					<li>
+						<a href='/documentation/components.html'>
+							Components
+						</a>
+					</li>
+					<li>
 						<a href='/documentation/2d.html'>
 							2D Graphics
 						</a>

--- a/documentation/index.html
+++ b/documentation/index.html
@@ -64,6 +64,21 @@
 						</a>
 					</li>
 					<li>
+						<a href='/documentation/entities.html'>
+							Entities
+						</a>
+					</li>
+					<li>
+						<a href='/documentation/events.html'>
+							Events
+						</a>
+					</li>
+					<li>
+						<a href='/documentation/components.html'>
+							Components
+						</a>
+					</li>
+					<li>
 						<a href='/documentation/2d.html'>
 							2D Graphics
 						</a>
@@ -114,7 +129,13 @@
 
 		<h2> Documentation for Crafty.js </h2>
 		<p>This documentation is meant to provide an overview of how to use Crafty, going over some common topics.</p>
-<p>For full documentation, check out the complete <a href="/api">API reference</a>!</p>
+<ul>
+<li>To get up and running quickly, check out the guide to <a href="/getting-started/">getting started</a></li>
+<li><p>If you want an overview of Crafty&#39;s basic mechanisms, check out the sections on <a href="/documentation/entities.html">entities</a>, <a href="events.html">events</a>, and <a href="components.html">custom components</a>.</p>
+</li>
+<li><p>For full documentation, check out the complete <a href="/api">API reference</a>!</p>
+</li>
+</ul>
 
 	</div>
 </div>

--- a/documentation/keyboard.html
+++ b/documentation/keyboard.html
@@ -64,6 +64,21 @@
 						</a>
 					</li>
 					<li>
+						<a href='/documentation/entities.html'>
+							Entities
+						</a>
+					</li>
+					<li>
+						<a href='/documentation/events.html'>
+							Events
+						</a>
+					</li>
+					<li>
+						<a href='/documentation/components.html'>
+							Components
+						</a>
+					</li>
+					<li>
 						<a href='/documentation/2d.html'>
 							2D Graphics
 						</a>

--- a/documentation/mouse.html
+++ b/documentation/mouse.html
@@ -64,6 +64,21 @@
 						</a>
 					</li>
 					<li>
+						<a href='/documentation/entities.html'>
+							Entities
+						</a>
+					</li>
+					<li>
+						<a href='/documentation/events.html'>
+							Events
+						</a>
+					</li>
+					<li>
+						<a href='/documentation/components.html'>
+							Components
+						</a>
+					</li>
+					<li>
 						<a href='/documentation/2d.html'>
 							2D Graphics
 						</a>
@@ -113,7 +128,7 @@
 		</span>
 
 		<h2> Mouse </h2>
-		<p>If you want an entity to interact with mouse events, add the <a href="/api/Mouse.html">Mouse</a> component.  It will then be passed the standard DOM-style mouse events: &quot;MouseDown&quot;, &quot;Click&quot;, etc.  (Note the capitilization.)</p>
+		<p>If you want an entity to interact with mouse events, add the <a href="/api/Mouse.html">Mouse</a> component.  It will then be passed the standard DOM-style mouse events: &quot;MouseDown&quot;, &quot;Click&quot;, etc.  (Note the capitalization.)</p>
 <ul>
 <li>Entities in a DOM layer will directly use the native DOM events</li>
 <li>Crafty implements picking in other layers using the entity&#39;s MBR</li>

--- a/documentation/scenes.html
+++ b/documentation/scenes.html
@@ -64,6 +64,21 @@
 						</a>
 					</li>
 					<li>
+						<a href='/documentation/entities.html'>
+							Entities
+						</a>
+					</li>
+					<li>
+						<a href='/documentation/events.html'>
+							Events
+						</a>
+					</li>
+					<li>
+						<a href='/documentation/components.html'>
+							Components
+						</a>
+					</li>
+					<li>
 						<a href='/documentation/2d.html'>
 							2D Graphics
 						</a>
@@ -114,7 +129,7 @@
 
 		<h2> Scenes </h2>
 		<p><a href="/api/Crafty-scene.html">Scenes</a> are a way to organize your game.</p>
-<p>A scene is defined by a name, a setupt function called when the scene starts, and (optionally) a function that&#39;s called when the scene ends.  When a new scene is started, the current scene is automatically ended.  Importantly, any entity with the <code>2D</code> component will be destroyed when this happens, providing a clean slate for the next scene.  Likewise, the viewport will be reset to its default values.</p>
+<p>A scene is defined by a name, a setup function called when the scene starts, and (optionally) a function that&#39;s called when the scene ends.  When a new scene is started, the current scene is automatically ended.  Importantly, any entity with the <code>2D</code> component will be destroyed when this happens, providing a clean slate for the next scene.  Likewise, the viewport will be reset to its default values.</p>
 <p>If an entity should not be destroyed by a new scene, you can give it  the <code>&quot;Persist&quot;</code> component.  (Persist doesn&#39;t provide any other functionality; you can use components to categorize and tag entities.)</p>
 <p>You can pass in a single object as data to the setup function.  The general syntax is:</p>
 <pre><code><span class="hljs-comment">// Defining a new scene with an init function</span>

--- a/documentation/sound.html
+++ b/documentation/sound.html
@@ -64,6 +64,21 @@
 						</a>
 					</li>
 					<li>
+						<a href='/documentation/entities.html'>
+							Entities
+						</a>
+					</li>
+					<li>
+						<a href='/documentation/events.html'>
+							Events
+						</a>
+					</li>
+					<li>
+						<a href='/documentation/components.html'>
+							Components
+						</a>
+					</li>
+					<li>
 						<a href='/documentation/2d.html'>
 							2D Graphics
 						</a>

--- a/documentation/sprites.html
+++ b/documentation/sprites.html
@@ -64,6 +64,21 @@
 						</a>
 					</li>
 					<li>
+						<a href='/documentation/entities.html'>
+							Entities
+						</a>
+					</li>
+					<li>
+						<a href='/documentation/events.html'>
+							Events
+						</a>
+					</li>
+					<li>
+						<a href='/documentation/components.html'>
+							Components
+						</a>
+					</li>
+					<li>
 						<a href='/documentation/2d.html'>
 							2D Graphics
 						</a>
@@ -118,7 +133,7 @@
 <p><img src="/images/glitch_walker.png" height=114 width=416 /></p>
 <p>In this case, it depicts multiple frames of a single animation, but it&#39;s common for sprite sheets to combine many different animations.</p>
 <h2 id="loading-sprite-sheets">Loading sprite sheets</h2>
-<p>To prepare the sheets for use, you need to not only load them, but specify the locations of individual spirtes within them.  This can be done in one step with <a href="/api/Crafty-loader.html"><code>Crafty.load</code></a>.</p>
+<p>To prepare the sheets for use, you need to not only load them, but specify the locations of individual sprites within them.  This can be done in one step with <a href="/api/Crafty-loader.html"><code>Crafty.load</code></a>.</p>
 <pre><code><span class="hljs-keyword">var</span> assetsObj = {
     <span class="hljs-string">"sprites"</span>: {
         <span class="hljs-comment">// This spritesheet has 16 images, in a 2 by 8 grid</span>

--- a/documentation/text.html
+++ b/documentation/text.html
@@ -64,6 +64,21 @@
 						</a>
 					</li>
 					<li>
+						<a href='/documentation/entities.html'>
+							Entities
+						</a>
+					</li>
+					<li>
+						<a href='/documentation/events.html'>
+							Events
+						</a>
+					</li>
+					<li>
+						<a href='/documentation/components.html'>
+							Components
+						</a>
+					</li>
+					<li>
 						<a href='/documentation/2d.html'>
 							2D Graphics
 						</a>

--- a/source/_layouts/documentation
+++ b/source/_layouts/documentation
@@ -13,6 +13,21 @@ layout: default
 						</a>
 					</li>
 					<li>
+						<a href='/documentation/entities.html'>
+							Entities
+						</a>
+					</li>
+					<li>
+						<a href='/documentation/events.html'>
+							Events
+						</a>
+					</li>
+					<li>
+						<a href='/documentation/components.html'>
+							Components
+						</a>
+					</li>
+					<li>
 						<a href='/documentation/2d.html'>
 							2D Graphics
 						</a>

--- a/source/documentation/components.md
+++ b/source/documentation/components.md
@@ -1,0 +1,98 @@
+---
+title: Custom Components
+layout: documentation
+---
+
+Crafty has a lot of built-in components, but creating your own is a good way to organize your game.
+
+In several examples we've created colored squares, and we've repeated that code a *lot*.  For instance, the code below creates two squares:
+
+```
+var sq1 = Crafty.e("2D, Canvas, Color")
+	.attr({x:10, y:10, w:30, h:30})
+	.color("red");
+var sq1 = Crafty.e("2D, Canvas, Color")
+	.attr({x:150, y:100, w:30, h:30})
+	.color("green");
+```
+
+Now, you could create a function that simply generates such a square, but the Crafty way is to use components.  Define a component by using [`Crafty.c`](/api/Crafty-c.html).
+
+```
+Crafty.c("Square", {
+	// This function will be called when the component is added to an entity
+	// So it sets up the things that both our entities had in common
+	init: function() {
+		this.addComponent("2D, Canvas, Color");
+		this.w = 30;
+		this.h = 30;
+	},
+
+	// Our two entities had different positions, 
+	// so we define a method for setting the position
+	place: function(x, y) {
+		this.x = x;
+		this.y = y;
+
+		// There's no magic to method chaining.
+		// To allow it, we have to return the entity!
+		return this;
+	}
+})
+```
+
+`Crafty.c` takes two arguments: the first is the name of the component, the second is an object which defines its methods and properties.  When the component is added to an entity, all the methods and properties are copied to the entity in question.  The `init` field is treated specially, and is called when the component is added to an entity.  (You can also define a `remove` function that will be run when the component is removed, or right before the entity is destroyed.)
+
+With the above definition, our original code could be rewritten as
+
+```
+var sq1 = Crafty.e("Square")
+	.place(10, 10)
+	.color("red");
+
+var sq2 = Crafty.e("Square")
+	.place(150, 100)
+	.color("green");
+```
+
+We've taken everything that the two entities had in common, and put it in the `init` function of our component.  This is a very common way to reuse code between entities.  In some ways it's a bit like "Square" inherits the methods of the other components; by adding "Square" to an entity, we automatically get all the methods of "Color".
+
+Keep in mind that the method chaining technique (calling `e.place().color()`) is only possible because we explicitly return `this` from our custom method.  Forgetting to do so can be a common source of errors, so keep that in mind if you get a hard-to-pin-down "method undefined" message.
+
+## The nitty gritty
+
+Sometimes you might need to know exactly how components are added to an entity.  (If the component has previously been added to an entity, it won't be further modified.)
+
+- First a flag indicating the existence of the component is set
+- Then all properties are copied over from the component's object.  If any already exist, they will be overwritten.
+- If a property is an object or array, it is copied by reference.
+- Finally, the init function of the component object is called.
+ 
+### The shared object trap
+
+As mentioned above, objects and arrays are copied by reference.  This can cause unexpected behavior if you're not careful:
+
+```
+Crafty.c("MyComponent", {
+	sharedObject: {a:1, b:2}
+});
+var e1 = Crafty.e("MyComponent");
+var e2 = Crafty.e("MyComponent");
+e1.sharedObject.a = 5;
+console.log(e2.sharedObject.a); // Logs 5!
+```
+
+If you want a property to be an object, but *don't* want it shared between entities, the solution is to create a new object inside the init method:
+
+```
+Crafty.c("MyComponent", {
+	init: function() {
+		this.myObject = {a:1, b:2};
+	}
+});
+var e1 = Crafty.e("MyComponent");
+var e2 = Crafty.e("MyComponent");
+e1.myObject.a = 5;
+console.log(e2.myObject.a); // Logs the original value of 1
+```
+

--- a/source/documentation/entities.md
+++ b/source/documentation/entities.md
@@ -1,0 +1,138 @@
+---
+title: Working with entities
+layout: documentation
+---
+
+An entity is some *thing* in your game.  If that sounds vague, it's because practically anything can be an entity -- the player, the enemies, a projectile, a high score counter, or a menu item.
+
+Entities are made up of components, which you can think of as bundles of functionality.  Crafty provides several built-in components, and you can also define your own with [`Crafty.c()`](/api/Crafty-c.html).
+
+## Creating entities
+
+You create an entity with [`Crafty.e()`](/api/Craft-e.html).  In most cases you'll pass in a list of the components you want to start with:
+
+```
+var square = Crafty.e("2D, Canvas, Color");
+```
+
+Typically you'll need to write some more code to actually *do* something with the entity, but the above is all you need to create it.  In fact, you don't even need to assign the entity to a variable -- just calling `Crafty.e` is enough, and we'll learn later how to manipulate entities without a direct reference.
+
+## Core properties and methods
+
+There are certain properties and methods that every entity shares, even if no components have been added.  You'll find these documented under [Crafty Core](/api/Crafty Core.html).
+
+### Component methods
+
+You can [add](api/Crafty Core.html#-addComponent) and [remove](http://craftyjs.com/api/Crafty%20Core.html#-removeComponent) components to an entity after it has been created.  So instead of our previous code, we could have written:
+
+```
+var square = Crafty.e("2D, Canvas");
+square.addComponent("Color");
+```
+
+If we no longer wanted our component to appear as a colored square, we could remove that component later:
+
+```
+square.removeComponent("Color", false)
+```
+
+We pass in `false` to `removeComponent()` because we want to actually remove all properties and methods associated with the component.
+
+To learn whether an entity has a particular component, you can use the `has()` method.  For instance, perhaps we want to check if an entity might explode:
+
+```
+if (e.has("Explode"))
+	e.explode();
+```
+
+### Setting properties
+
+A component such as [2D](/api/api.html) might interact with certain properties of an entity.  You can set them directly, or use `attr` as a shorthand for setting several at once.  So this:
+```
+square.x = 5;
+square.y = 10;
+```
+is equivalent to
+```
+square.attr({x:5, y:10})
+```
+
+### Events
+
+Crafty uses both global and local events for communication amongst entities and components.  To create an event listener, you can use the `.bind()` method.  Let's make our previous square switch colors in response to an event.
+
+```
+// Bind a function to the event
+square.bind("ChangeColor", function(eventData){
+		// `this` refers to the entity
+		this.color(eventData.color);
+	})
+// Trigger that event directly on the entity
+square.trigger("ChangeColor", {color:"blue"});
+```
+
+In the above code, we directly trigger the effect on the entity.  You can also trigger an effect globally, which means *all* entities will receive it.  Events are often used for communication between components -- you can find information about such events in the component's documentation.
+
+If a function should only be triggered once, you can bind with the `one()` method instead of `bind()`.  To remove a bound event, use `unbind()`.
+
+See the section on [events](/documentation/events.html) for more discussion of the event system.
+
+### Destruction
+
+Calling the `destroy()` method of an entity will destroy it.
+
+
+## Selecting entities
+
+When an entity is created, it's given a unique ID.  To find this id, you can call the `getId()` method.
+
+If you know the id of an entity, you can get a reference to it like this:
+```
+var secondEntity = Crafty(2);
+```
+
+[`Crafty`](/api/Crafty.html) is both an object and a function.  This might be familiar to you from working with jQuery.  And as in jQuery, you can select multiple entities at once, typically based on what components they have:
+
+```
+// Select all entities with the 2D components
+Crafty("2D");
+// select all entities with both 2D and DOM
+Crafty("2D DOM");
+// select entities with either DOM or Canvas
+Crafty("DOM, Canvas");
+// Select all entities
+Crafty("*");
+```
+
+Once you have a selection, you can call event-related methods directly:
+
+```
+// Bind a function to *every* entity with the Keyboard component
+Crafty("Keyboard").bind("KeyDown", function(){
+	// Do something on keydown
+});
+
+// Explode all the things!
+Crafty("*").trigger("Explode");
+```
+
+You can run a function in the context of every entity:
+```
+// Move every 2D entity 5 pixels to the right
+Crafty("2D").each(function() {
+	this.x += 5;
+});
+```
+
+If you need to know how many entities are in the selection, you can check the `length` property.
+
+You can use `get()` to either obtain an array containing every entity in the selection, or the entity at a particular index:
+
+```
+// Get the first Canvas entity
+var first_entity = Crafty("Canvas").get(0);
+// Get an array of all 2D entities
+var array_of_entities = Crafty("2D").get();
+// Convert to an array of ids, rather than entities
+var array_of_ids = Crafty("2D").toArray();
+```

--- a/source/documentation/events.md
+++ b/source/documentation/events.md
@@ -1,0 +1,133 @@
+---
+title: The Event System
+layout: documentation
+---
+
+Crafty uses events for communication.
+
+The basic idea is to bind functions to named events.  When that event is triggered, the function will then be called directly.  Here's a very simple example:
+
+```
+// Create a red square
+var square = Crafty.e("2D, Canvas, Color")
+		.attr({x:10,y:10, w:30, h:30})
+		.color("blue");
+
+// When a "Blush" event is triggered, turn pink
+square.bind("Blush", function() {
+	// the function will be called in the context of the entity
+	this.color("pink")
+});
+
+// Trigger the event, causing the square to turn pink
+square.trigger("Blush");
+```
+
+Above, we bind to an event on an entity and then immediately trigger it.  More typically, the event would be triggered elsewhere in the game logic.  You can bind multiple functions to the same event, but you generally shouldn't rely on them executing in a particular order.
+
+Every entity automatically gets several methods which relate to events; these are documented under [Crafty Core](/api/Crafty Core.html).  We'll explore aspects of this in more detail below.	
+
+## Passing data
+
+Many events pass data to the bound function.  Let's make the above code a bit more generic by defining a "ChangeColor" event:
+
+```
+square.bind("ChangeColor", function(color) {
+	this.color(color);
+});
+
+square.trigger("ChangeColor", "pink"); // Turn pink
+```
+
+When you trigger the event, a single paramter can be passed as the second argument.  This isn't too limiting, because you can always pass an object -- for instance, if we wanted `"ChangeColor"` to use rgb values instead of a single name:
+
+```
+// Assume that color is an object
+square.bind("ChangeColor", function(color) {
+	this.color(color.r, color,g, color.b);
+})
+
+// Specify the RGB values corresponding to pink
+square.trigger("ChangeColor", {r:255, g:192, b:203});
+```
+
+## Unbinding events
+
+To unbind an event, you need a reference to the bound function, so you typically can't use an anonymous one.  Modifying our initial example:
+
+```
+var turnPink = function() { 
+	this.color("pink");
+}
+
+// Bind the function to an event
+square.bind("Blush", turnPink);
+
+// Immediately unbind it!
+square.unbind("Blush", turnPink);
+```
+
+Very commonly, you might want a function to only be triggered once.  In that case, you can bind it with `.one()` instead of `.bind()`:
+
+```
+// Use the .one() method instead of .bind()
+square.one("JumpRight", function() {
+	// Move 10 px to the right
+	this.x += 100;
+});
+
+// If we trigger the event twice, the bound function will be called only the first time
+square.trigger("JumpRight");
+square.trigger("JumpRight");
+```
+
+## Working with built-in events
+
+Many of Crafty's built-in components will trigger events, and the more useful ones will be documented in the API reference.  For instance, the [`2D` component](/api/2D.html) tells us that it will trigger a "Move" event any time the object's position changes, and that the event will pass along an object containing the entity's old position.
+
+```
+// Bind a function to the "Move" event
+// It will log the initial and new x position anytime the entity moves
+square.bind("Move", function(oldPosition) {
+	console.log(oldPosition._x, this.x);
+});
+
+square.x = 100; // Will print "10, 100"
+```
+
+As you explore Crafty's [API](/api/), you'll see such built-in events highlighted in green.
+
+## Global events
+
+All the events we've discussed so far have been local to one specific entity.  But events can be triggered globally as well -- they will then trigger on *every* entity.
+
+```
+// Define two entities at x=5 and x=10
+var varrick = Crafty.e("2D").attr({x:5});
+var xhuli = Crafty.e("2D").attr({x:10});
+
+// Bind to an event called "Thing"
+varrick.bind("Thing", function() { this.x += 20; });
+xhuli.bind("Thing", function() { this.x += 10; });
+
+// Do the thing!
+// varrick and xhuli will *both* move to the right
+Crafty.trigger("Thing");
+
+// You can still trigger the same events directly on an entity
+xhuli.trigger("Thing");
+```
+
+You can also bind to events directly on the Crafty object:
+
+```
+Crafty.bind("Thing", function() {
+	console.log("Crafty does the thing.")
+});
+```
+
+In such a globally bound function, the context will be the global Crafty object (`this === Crafty`).
+
+`Crafty.unbind()` and `Crafty.one()` also exist, and act exactly as you'd expect!
+
+One particularly important built-in global event is "EnterFrame".  You can read more about it in the section on Crafty's [game loop](/documentation/gameloop.html)

--- a/source/documentation/index.md
+++ b/source/documentation/index.md
@@ -5,4 +5,7 @@ layout: documentation
 
 This documentation is meant to provide an overview of how to use Crafty, going over some common topics.
 
-For full documentation, check out the complete [API reference](/api)!
+- To get up and running quickly, check out the guide to [getting started](/getting-started/)
+- If you want an overview of Crafty's basic mechanisms, check out the sections on [entities](/documentation/entities.html), [events](events.html), and [custom components](components.html).
+
+- For full documentation, check out the complete [API reference](/api)!

--- a/source/documentation/mouse.md
+++ b/source/documentation/mouse.md
@@ -3,7 +3,7 @@ title: Mouse
 layout: documentation
 ---
 
-If you want an entity to interact with mouse events, add the [Mouse](/api/Mouse.html) component.  It will then be passed the standard DOM-style mouse events: "MouseDown", "Click", etc.  (Note the capitilization.)
+If you want an entity to interact with mouse events, add the [Mouse](/api/Mouse.html) component.  It will then be passed the standard DOM-style mouse events: "MouseDown", "Click", etc.  (Note the capitalization.)
 
 - Entities in a DOM layer will directly use the native DOM events
 - Crafty implements picking in other layers using the entity's MBR

--- a/source/documentation/scenes.md
+++ b/source/documentation/scenes.md
@@ -5,7 +5,7 @@ layout: documentation
 
 [Scenes](/api/Crafty-scene.html) are a way to organize your game.
 
-A scene is defined by a name, a setupt function called when the scene starts, and (optionally) a function that's called when the scene ends.  When a new scene is started, the current scene is automatically ended.  Importantly, any entity with the `2D` component will be destroyed when this happens, providing a clean slate for the next scene.  Likewise, the viewport will be reset to its default values.
+A scene is defined by a name, a setup function called when the scene starts, and (optionally) a function that's called when the scene ends.  When a new scene is started, the current scene is automatically ended.  Importantly, any entity with the `2D` component will be destroyed when this happens, providing a clean slate for the next scene.  Likewise, the viewport will be reset to its default values.
 
 If an entity should not be destroyed by a new scene, you can give it  the `"Persist"` component.  (Persist doesn't provide any other functionality; you can use components to categorize and tag entities.)
 

--- a/source/documentation/sprites.md
+++ b/source/documentation/sprites.md
@@ -13,7 +13,7 @@ In this case, it depicts multiple frames of a single animation, but it's common 
 
 ## Loading sprite sheets
 
-To prepare the sheets for use, you need to not only load them, but specify the locations of individual spirtes within them.  This can be done in one step with [`Crafty.load`](/api/Crafty-loader.html).
+To prepare the sheets for use, you need to not only load them, but specify the locations of individual sprites within them.  This can be done in one step with [`Crafty.load`](/api/Crafty-loader.html).
 
 ```
 var assetsObj = {


### PR DESCRIPTION
These are pretty basic topics when using Crafty, so we should have documentation that provides an overview of the topics.

This patch also fixes some typos I noticed in other doc pages.