### PR TITLE
Only remove parent from link text if it's the initial string

### DIFF
--- a/source/api-gen/doc-components.jsx
+++ b/source/api-gen/doc-components.jsx
@@ -473,7 +473,10 @@ var EventPage = React.createClass({
 var InternalLink = React.createClass({
     render: function() {
       var cleanTarget = cleanName(this.props.target);
-      var linkText = this.props.target.replace(this.props.parent, "");
+      var linkText = this.props.target;
+      if (linkText.indexOf(this.props.parent) == 0 ) {
+        linkText = linkText.replace(this.props.parent, "");
+      }
       return <a href={"#" + cleanTarget}>{linkText}</a>
     }
 });


### PR DESCRIPTION
Noticed this bug while adding a method called `dynamicTextGeneration` to the `Text` component.